### PR TITLE
perf(attribute): handle more numeric types, avoid reflection on hot path

### DIFF
--- a/attribute_bench_test.go
+++ b/attribute_bench_test.go
@@ -1,0 +1,172 @@
+package otelemetry
+
+import (
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+// sink prevents the compiler from optimizing benchmarked calls away.
+var (
+	sinkKV  attribute.KeyValue
+	sinkKVs []attribute.KeyValue
+)
+
+// --- Individual types through Attribute (any -> type switch) ---
+
+func BenchmarkAttribute_String(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		sinkKV = Attribute("http.method", "GET")
+	}
+}
+
+func BenchmarkAttribute_Int(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		sinkKV = Attribute("http.status_code", 200)
+	}
+}
+
+func BenchmarkAttribute_Int64(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		sinkKV = Attribute("bytes", int64(4096))
+	}
+}
+
+func BenchmarkAttribute_Float64(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		sinkKV = Attribute("latency_ms", 12.5)
+	}
+}
+
+func BenchmarkAttribute_Bool(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		sinkKV = Attribute("cache.hit", true)
+	}
+}
+
+// Newly covered numeric types (previously hit the fmt.Sprintf default branch).
+
+func BenchmarkAttribute_Int32(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		sinkKV = Attribute("shard", int32(12))
+	}
+}
+
+func BenchmarkAttribute_Uint(b *testing.B) {
+	var v uint = 42
+	b.ReportAllocs()
+	for b.Loop() {
+		sinkKV = Attribute("count", v)
+	}
+}
+
+func BenchmarkAttribute_Uint64(b *testing.B) {
+	var v uint64 = 4096
+	b.ReportAllocs()
+	for b.Loop() {
+		sinkKV = Attribute("bytes", v)
+	}
+}
+
+func BenchmarkAttribute_Float32(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		sinkKV = Attribute("ratio", float32(0.5))
+	}
+}
+
+// --- Direct OTel constructors (no any boxing, no type switch) ---
+
+func BenchmarkDirect_String(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		sinkKV = attribute.String("http.method", "GET")
+	}
+}
+
+func BenchmarkDirect_Int(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		sinkKV = attribute.Int("http.status_code", 200)
+	}
+}
+
+func BenchmarkDirect_Int64(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		sinkKV = attribute.Int64("bytes", 4096)
+	}
+}
+
+func BenchmarkDirect_Float64(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		sinkKV = attribute.Float64("latency_ms", 12.5)
+	}
+}
+
+func BenchmarkDirect_Bool(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		sinkKV = attribute.Bool("cache.hit", true)
+	}
+}
+
+// --- The expensive default branch: fmt.Sprintf("%#v", v) + reflection ---
+
+type customType struct {
+	ID   int
+	Name string
+}
+
+func BenchmarkAttribute_DefaultBranch_Struct(b *testing.B) {
+	v := customType{ID: 7, Name: "abc"}
+	b.ReportAllocs()
+	for b.Loop() {
+		sinkKV = Attribute("payload", v)
+	}
+}
+
+// Stringer branch: v.String() typically allocates.
+func BenchmarkAttribute_Stringer_Time(b *testing.B) {
+	v := time.Unix(1700000000, 0)
+	b.ReportAllocs()
+	for b.Loop() {
+		sinkKV = Attribute("ts", v)
+	}
+}
+
+// --- Realistic hot path: building a set of span attributes per request ---
+
+func BenchmarkAttribute_RequestSet(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		sinkKVs = []attribute.KeyValue{
+			Attribute("http.method", "GET"),
+			Attribute("http.route", "/api/v1/users"),
+			Attribute("http.status_code", 200),
+			Attribute("http.request_bytes", int64(1024)),
+			Attribute("cache.hit", true),
+		}
+	}
+}
+
+func BenchmarkDirect_RequestSet(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		sinkKVs = []attribute.KeyValue{
+			attribute.String("http.method", "GET"),
+			attribute.String("http.route", "/api/v1/users"),
+			attribute.Int("http.status_code", 200),
+			attribute.Int64("http.request_bytes", 1024),
+			attribute.Bool("cache.hit", true),
+		}
+	}
+}

--- a/otel_test.go
+++ b/otel_test.go
@@ -3,6 +3,7 @@ package otelemetry
 import (
 	"context"
 	"errors"
+	"math"
 	"net/http"
 	"testing"
 
@@ -231,8 +232,18 @@ func TestAttribute(t *testing.T) {
 	}{
 		{"string", "hello", attribute.STRING},
 		{"int", 42, attribute.INT64},
+		{"int8", int8(42), attribute.INT64},
+		{"int16", int16(42), attribute.INT64},
+		{"int32", int32(42), attribute.INT64},
 		{"int64", int64(42), attribute.INT64},
+		{"uint", uint(42), attribute.INT64},
+		{"uint8", uint8(42), attribute.INT64},
+		{"uint16", uint16(42), attribute.INT64},
+		{"uint32", uint32(42), attribute.INT64},
+		{"uint64", uint64(42), attribute.INT64},
+		{"uint64_overflow", uint64(math.MaxUint64), attribute.STRING}, // no int64 fit -> string
 		{"bool", true, attribute.BOOL},
+		{"float32", float32(3.14), attribute.FLOAT64},
 		{"float64", 3.14, attribute.FLOAT64},
 		{"string_slice", []string{"a", "b"}, attribute.STRINGSLICE},
 		{"int_slice", []int{1, 2}, attribute.INT64SLICE},
@@ -250,6 +261,11 @@ func TestAttribute(t *testing.T) {
 			assert.Equal(t, tt.wantType, attr.Value.Type())
 		})
 	}
+
+	t.Run("uint64_overflow_value", func(t *testing.T) {
+		attr := Attribute("k", uint64(math.MaxUint64))
+		assert.Equal(t, "18446744073709551615", attr.Value.AsString())
+	})
 }
 
 // --- LogAttribute() ---

--- a/util.go
+++ b/util.go
@@ -2,6 +2,8 @@ package otelemetry
 
 import (
 	"fmt"
+	"math"
+	"strconv"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/log"
@@ -30,22 +32,50 @@ func parseAttribute(key string, value any) attribute.KeyValue {
 		attr = attribute.Int(key, v)
 	case []int:
 		attr = attribute.IntSlice(key, v)
+	case int8:
+		attr = attribute.Int64(key, int64(v))
+	case int16:
+		attr = attribute.Int64(key, int64(v))
+	case int32:
+		attr = attribute.Int64(key, int64(v))
 	case int64:
 		attr = attribute.Int64(key, v)
 	case []int64:
 		attr = attribute.Int64Slice(key, v)
+	case uint:
+		attr = uintAttribute(key, uint64(v))
+	case uint8:
+		attr = attribute.Int64(key, int64(v))
+	case uint16:
+		attr = attribute.Int64(key, int64(v))
+	case uint32:
+		attr = attribute.Int64(key, int64(v))
+	case uint64:
+		attr = uintAttribute(key, v)
 	case bool:
 		attr = attribute.Bool(key, v)
 	case []bool:
 		attr = attribute.BoolSlice(key, v)
+	case float32:
+		attr = attribute.Float64(key, float64(v))
 	case float64:
 		attr = attribute.Float64(key, v)
 	case []float64:
 		attr = attribute.Float64Slice(key, v)
 	default:
-		attr = attribute.String(key, fmt.Sprintf("%#v", v))
+		attr = attribute.String(key, fmt.Sprintf("%+v", v))
 	}
 	return attr
+}
+
+// uintAttribute records an unsigned integer as an Int64 attribute when it fits,
+// falling back to a decimal string when it would overflow int64 (OTel has no
+// native unsigned attribute type).
+func uintAttribute(key string, v uint64) attribute.KeyValue {
+	if v <= math.MaxInt64 {
+		return attribute.Int64(key, int64(v))
+	}
+	return attribute.String(key, strconv.FormatUint(v, 10))
 }
 
 func LogAttribute(k string, v any) log.KeyValue {


### PR DESCRIPTION
## What

Extends `parseAttribute` (`util.go`) to natively handle numeric types that previously fell through to the reflection-based `fmt.Sprintf` default branch.

## Why

Benchmarks showed that types outside the original type switch — `int8/16/32`, all `uint` variants, `float32` — hit `fmt.Sprintf("%#v", v)`, costing ~34 ns **+ 1 heap allocation** per call. Types already in the switch cost ~8 ns / 0 allocs (escape analysis keeps the `any` boxing on the stack). On hot paths (per-request span attributes, metrics in loops) those stray allocations add up.

## Benchmarks

Apple M4 Pro, Go 1.26, `go test -bench . -benchmem`.

### Numeric types through `Attribute` (after)

| Type | ns/op | B/op | allocs/op | Before (default branch) |
|------|------:|-----:|----------:|-------------------------|
| `int32`   |  8.3 | 0 | 0 | ~34 ns, 1 alloc |
| `float32` |  8.3 | 0 | 0 | ~34 ns, 1 alloc |
| `uint`    | 11.2 | 0 | 0 | 33.8 ns, 4 B, 1 alloc |
| `uint64`  | 11.3 | 0 | 0 | ~34 ns, 1 alloc |

For reference, types already covered before this PR: `string`/`int`/`int64`/`float64`/`bool` ≈ 8–9 ns, 0 allocs; direct OTel constructors (`attribute.Int64` etc.) ≈ 3.5 ns, 0 allocs.

### `default` branch encoder: `%#v` → `%+v`

Struct `{ID:7, Name:"abc"}`, 3 runs:

| Format | ns/op | B/op | allocs/op | Output |
|--------|------:|-----:|----------:|--------|
| `%#v` (was) | ~118 | 48 | 1 | `otelemetry.customType{ID:7, Name:"abc"}` |
| `%+v` (now) |  ~99 | 16 | 1 | `{ID:7 Name:abc}` |
| `%v`        |  ~71 |  8 | 1 | `{7 abc}` |

`%+v` keeps field names, is ~1.2× faster, uses less scratch memory, and matches `parseLogAttribute` which already used `%+v`. `%v` is faster still but drops field names, so it was not chosen. The final string allocation is a hard floor — OTel retains the string, so arbitrary types always cost ≥1 alloc.

## Changes

- **New numeric cases** → `attribute.Int64` / `attribute.Float64`: `int8`, `int16`, `int32`, `uint8`, `uint16`, `uint32`, `uint`, `uint64`, `float32`.
- **`uintAttribute` helper**: `uint`/`uint64` map to `Int64` when they fit, else fall back to a decimal string (OTel has no unsigned attribute type; a blind `int64(v)` cast would corrupt large values into negatives).
- **`default` branch `%#v` → `%+v`** (see table above).
- **Tests**: extended table-driven `TestAttribute` with all new types + a value-correctness check for the `uint64` overflow fallback.
- **Benchmarks**: added `attribute_bench_test.go` comparing `Attribute` vs direct OTel constructors and covering the expensive `default`/`Stringer` branches.

## Verification

`go build ./...`, `go vet .`, `go test ./...` all pass.